### PR TITLE
Change Fixnum by Integer

### DIFF
--- a/lib/capataz.rb
+++ b/lib/capataz.rb
@@ -177,7 +177,7 @@ module Capataz
     end
 
     def handle(obj, options = {})
-      if obj.capataz_proxy? || [NilClass, Fixnum, Symbol, String, TrueClass, FalseClass].any? { |type| obj.is_a?(type) }
+      if obj.capataz_proxy? || [NilClass, Integer, Symbol, String, TrueClass, FalseClass].any? { |type| obj.is_a?(type) }
         obj
       elsif obj.is_a?(Hash)
         Capataz::HashProxy.new(obj)


### PR DESCRIPTION
Ruby 2.4 unifies Fixnum and Bignum into Integer

https://blog.bigbinary.com/2016/11/18/ruby-2-4-unifies-fixnum-and-bignum-into-integer.html